### PR TITLE
Implement simple autogenerated screenshot tests. No screenshots places into `screenshots` folder yet

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,11 @@ android {
   testOptions {
     unitTests {
       isIncludeAndroidResources = true
+
+      // Roborazzi recommends to enable hardware render mode to enable PixelCopy
+      all {
+        it.systemProperties["robolectric.pixelCopyRenderMode"] = "hardware"
+      }
     }
   }
 }
@@ -60,7 +65,17 @@ dependencies {
   androidTestImplementation(libs.androidx.ui.test.junit4)
   debugImplementation(libs.androidx.ui.tooling)
   debugImplementation(libs.androidx.ui.test.manifest)
-  testDebugImplementation(libs.androidx.ui.test.junit4)
+  testImplementation(libs.androidx.ui.test.junit4)
   testDebugImplementation(libs.roborazzi)
   testDebugImplementation(libs.robolectric)
+  testDebugImplementation(libs.sergioSastre.composablePreviewScanner)
+  testDebugImplementation(libs.roborazzi.compose.preview.scanner.support)
+}
+
+roborazzi {
+  generateComposePreviewRobolectricTests {
+    enable = true
+    packages = listOf("ru.kartollika.screenshot.testing.ui.components")
+    includePrivatePreviews = true
+  }
 }

--- a/app/src/main/java/ru/kartollika/screenshot/testing/ui/components/Cards.kt
+++ b/app/src/main/java/ru/kartollika/screenshot/testing/ui/components/Cards.kt
@@ -1,0 +1,105 @@
+package ru.kartollika.screenshot.testing.ui.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ru.kartollika.screenshot.testing.ui.theme.ScreenshotTestingSampleAppTheme
+
+@Composable
+fun SmallCard(
+  modifier: Modifier = Modifier,
+  content: @Composable ColumnScope.() -> Unit = {}
+) {
+  Card(
+    modifier = modifier,
+    shape = MaterialTheme.shapes.small,
+    content = content
+  )
+}
+
+@Composable
+fun MediumCard(
+  modifier: Modifier = Modifier,
+  content: @Composable ColumnScope.() -> Unit = {}
+) {
+  Card(
+    modifier = modifier,
+    shape = MaterialTheme.shapes.medium,
+    content = content
+  )
+}
+
+@Composable
+fun LargeCard(
+  modifier: Modifier = Modifier,
+  content: @Composable ColumnScope.() -> Unit = {}
+) {
+  Card(
+    modifier = modifier,
+    shape = MaterialTheme.shapes.extraLarge,
+    content = content
+  )
+}
+
+@Composable
+private fun DefaultCardContent(
+  modifier: Modifier = Modifier
+) {
+  Column(
+    modifier = modifier
+      .padding(16.dp),
+    verticalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text("Test")
+    TextField(value = "", onValueChange = {})
+    Button(
+      onClick = {},
+    ) {
+      Text("Accept")
+    }
+  }
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SmallCardPreview() {
+  ScreenshotTestingSampleAppTheme {
+    SmallCard {
+      DefaultCardContent()
+    }
+  }
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun MediumCardPreview() {
+  ScreenshotTestingSampleAppTheme {
+    MediumCard {
+      DefaultCardContent()
+    }
+  }
+}
+
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LargeCardPreview() {
+  ScreenshotTestingSampleAppTheme {
+    LargeCard {
+      DefaultCardContent()
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.9.3"
 composeBom = "2024.04.01"
 roborazzi = "1.32.2"
 robolectric = "4.14"
+composablePreviewScanner = "0.4.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +29,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 roborazzi = { group = "io.github.takahirom.roborazzi", name = "roborazzi", version.ref = "roborazzi" }
+roborazzi-compose-preview-scanner-support = { module = "io.github.takahirom.roborazzi:roborazzi-compose-preview-scanner-support", version.ref = "roborazzi" }
+sergioSastre-ComposablePreviewScanner = { module = "io.github.sergio-sastre.ComposablePreviewScanner:android", version.ref = "composablePreviewScanner" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Автогенерация скриншот тестов используя Compose Preview Scanner + Roborazzi

Временный drawback
Скриншоты генерируются в папке /build. Оттуда их можно достать с помощью CI или локально перетащить

В дальнейшем эта проблема уйдет, когда мы сделаем свою реализацию теста